### PR TITLE
call getdents multiple times

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,38 +18,4 @@ $ lls > output.txt
 $ lls / > output.txt
 ```
 
-If you want to reduce the memory usage, you can specify the `-buf-size` option. If the size you specify is smaller than the actual size needed, you will not get the full file list.
-
-## FAQs
-
-### Q: I can't run lls
-
-If the size of the directory (`ls -dl`) is larger than 2GB, you may get the following error.
-
-```
-$ lls
-invalid argument
-```
-
-You can specify the size of the buffer by passing the `-buf-size` option. You can specify `2147483647`, which is 1 byte smaller than 2GB.
-
-```
-$ lls -buf-size 2147483647
-```
-
-### Q: I can't get a list of all files
-
-Maybe the size of the buffer is too small.
-
-For example, you run `lls -debug` and get the following output.
-
-```
-$ lls -debug
-bufSize: 4096; getdents ret: 4080
-```
-
-The `bufSize` is the actual size of the buffer passed to the system call, and `getdents ret` is the return value of the getdents system call, which is the number of bytes actually used in the buffer.
-
-It consumes about `(20+filename) bytes` per file. If the difference between these two numbers is less than one file, it is possible that there are still other files, but we are not able to list all of them.
-
-If you give a larger number to the `-buf-size` option, you should get a list of all files.
+If you want to change the memory usage, you can specify the `-buf-size` option (default: 5MB).

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -14,9 +14,9 @@ func TestRun_Success(t *testing.T) {
 	outStream, errStream := new(bytes.Buffer), new(bytes.Buffer)
 	cl := NewCLI(outStream, errStream)
 	target := "testdata"
-	status := cl.run(target, false, 0)
+	status := cl.run(target, false, 500)
 	if status != ExitCodeOK {
-		t.Errorf("ExitStatus=%d, want %d", status, ExitCodeOK)
+		t.Fatalf("ExitStatus=%d, want %d", status, ExitCodeOK)
 	}
 	actualList := strings.Split(outStream.String(), "\n")
 	// last element is unused


### PR DESCRIPTION
Getdents can be called multiple times. Set the default size of the buffer to 5MB and call it multiple times.