### PR TITLE
use bytes.IndexByte

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"flag"
 	"fmt"
 	"io"
@@ -137,7 +138,8 @@ func (c *CLI) run(target string, debug bool, bufSize int) int {
 			}
 
 			bb := (*[256]byte)(unsafe.Pointer(&dirent.Name[0]))
-			name := string(bb[0:blen(*bb)])
+			blen := bytes.IndexByte(bb[:], 0)
+			name := string(bb[0:blen])
 
 			if name == "." || name == ".." {
 				// ignore
@@ -148,13 +150,4 @@ func (c *CLI) run(target string, debug bool, bufSize int) int {
 	}
 
 	return ExitCodeOK
-}
-
-func blen(b [256]byte) int {
-	for i := 0; i < len(b); i++ {
-		if b[i] == 0 {
-			return i
-		}
-	}
-	return len(b)
 }


### PR DESCRIPTION
We can use `bytes.IndexByte` for this purpose, and I think it's faster because it is written in assembly using special machine instructions.