### PR TITLE
Add GitHub Actions Go version update support

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,16 @@
       "matchStrings": [
         "go-version-input: (?<currentValue>[0-9]*.[0-9]*.[0-9]*)"
       ]
+    },
+    {
+      "fileMatch": [
+        ".github/workflows/release.yml"
+      ],
+      "datasourceTemplate": "golang-version",
+      "depNameTemplate": "golang",
+      "matchStrings": [
+        "go-version: (?<currentValue>[0-9]*.[0-9]*.[0-9]*)"
+      ]
     }
   ],
   "postUpdateOptions": [


### PR DESCRIPTION
This pull request includes a change to the `renovate.json` file. The change adds a new block of configuration to match the version of Golang used in the `.github/workflows/release.yml` file. This will allow the Renovate bot to automatically update the Golang version in the release workflow when a new version is available.