### PR TITLE
update Go version to 1.23.0 and upgrade go-cmp to v0.7.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/catatsuy/lls
 
-go 1.20
+go 1.23.0
 
-require github.com/google/go-cmp v0.6.0
+require github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
-github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=


### PR DESCRIPTION
This pull request updates the dependencies and Go version in the `go.mod` file.

Dependency updates:

* Updated the Go version from `1.20` to `1.23.0`.
* Updated the `github.com/google/go-cmp` dependency from `v0.6.0` to `v0.7.0`.