### PR TITLE
Add Renovate Config Validator workflow and update renovate.json schema

### DIFF
--- a/.github/workflows/renovate-config-validator-ci.yml
+++ b/.github/workflows/renovate-config-validator-ci.yml
@@ -1,0 +1,20 @@
+name: Renovate Config Validator
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "renovate.json"
+      - ".github/workflows/renovate-config-validator-ci.yml"
+
+jobs:
+  renovate-config-validator:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: validate renovate.json
+        run: npx --package=renovate -c renovate-config-validator

--- a/renovate.json
+++ b/renovate.json
@@ -24,6 +24,17 @@
       "matchStrings": [
         "go-version: (?<currentValue>[0-9]*.[0-9]*.[0-9]*)"
       ]
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        ".github/workflows/go.yml"
+      ],
+      "datasourceTemplate": "golang-version",
+      "depNameTemplate": "golang",
+      "matchStrings": [
+        "go: \\[\"(?<currentValue>[0-9]*.[0-9]*.[0-9]*)\"\\]"
+      ]
     }
   ],
   "postUpdateOptions": [


### PR DESCRIPTION
This pull request includes changes to add a new GitHub Actions workflow for validating the Renovate configuration and updates to the `renovate.json` file to include a new regex match for Go version updates.

### New GitHub Actions workflow:

* [`.github/workflows/renovate-config-validator-ci.yml`](diffhunk://#diff-e519a4bcca8b109726730f425f70681c1ebc03420db40b019c222ff042b1fd76R1-R20): Added a new workflow named "Renovate Config Validator" that triggers on workflow dispatch and pull requests affecting specific files. It includes a job to validate the `renovate.json` configuration using `npx renovate-config-validator`.

### Updates to Renovate configuration:

* [`renovate.json`](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57R27-R37): Added a new custom regex match for Go version updates in `.github/workflows/go.yml` to ensure that the Go version is kept up to date.