### PR TITLE
Simplify Go version setup in CI workflow and update regex

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,15 +4,11 @@ jobs:
   test:
     name: Build
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go: ["1.24.1"]
     steps:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go }}
-        id: go
+          go-version: 1.24.1
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4

--- a/renovate.json
+++ b/renovate.json
@@ -33,7 +33,7 @@
       "datasourceTemplate": "golang-version",
       "depNameTemplate": "golang",
       "matchStrings": [
-        "go: \\[\"(?<currentValue>[0-9]*.[0-9]*.[0-9]*)\"\\]"
+        "go-version: (?<currentValue>[0-9]*.[0-9]*.[0-9]*)"
       ]
     }
   ],


### PR DESCRIPTION
This pull request includes changes to streamline the Go version setup in the GitHub Actions workflow and update the `renovate.json` configuration for better version matching.

Changes to GitHub Actions workflow:

* [`.github/workflows/go.yml`](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL7-R11): Removed the matrix strategy and directly set the Go version to `1.24.1` in the `setup-go` action.

Updates to Renovate configuration:

* [`renovate.json`](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L36-R36): Modified the `matchStrings` pattern to match the new format used in the GitHub Actions workflow for specifying the Go version.