### PR TITLE
update renovate-config-validator-ci.yml to use renovate@latest

### DIFF
--- a/.github/workflows/renovate-config-validator-ci.yml
+++ b/.github/workflows/renovate-config-validator-ci.yml
@@ -17,4 +17,4 @@ jobs:
         uses: actions/checkout@v4
 
       - name: validate renovate.json
-        run: npx --package=renovate -c renovate-config-validator
+        run: npx --package=renovate@latest -c renovate-config-validator


### PR DESCRIPTION
This pull request updates the Renovate configuration validation process in the GitHub Actions workflow to ensure the latest version of the Renovate package is used.

* [`.github/workflows/renovate-config-validator-ci.yml`](diffhunk://#diff-e519a4bcca8b109726730f425f70681c1ebc03420db40b019c222ff042b1fd76L20-R20): Updated the `run` command to use `renovate@latest` in the `npx` command for validating `renovate.json`, ensuring the validation uses the most up-to-date version of the Renovate tool.