### PR TITLE
use unsafe.String for optimization

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -137,7 +137,9 @@ func (c *CLI) run(target string, debug bool, bufSize int) int {
 			}
 
 			bb := (*[256]byte)(unsafe.Pointer(&dirent.Name))
-			name := string(bb[0:blen(*bb)])
+			// name := string(bb[0:blen(*bb)])
+			// to optimize for speed, do the following:
+			name := unsafe.String(&bb[0], blen(*bb))
 
 			if name == "." || name == ".." {
 				// ignore


### PR DESCRIPTION
This pull request includes an optimization to the `run` method in `cli/cli.go` to improve performance when handling strings.

Performance optimization:

* [`cli/cli.go`](diffhunk://#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6L140-R142): Replaced the existing string conversion logic using `string(bb[0:blen(*bb)])` with `unsafe.String(&bb[0], blen(*bb))` to optimize for speed.