### PR TITLE
rename depNameTemplate from golang to go

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,9 +9,9 @@
         "/.github/workflows/security.yml/"
       ],
       "datasourceTemplate": "golang-version",
-      "depNameTemplate": "golang",
+      "depNameTemplate": "go-security",
       "matchStrings": [
-        "go-version-input: (?<currentValue>[0-9]*.[0-9]*.[0-9]*)"
+        "go-version-input: \"?(?<currentValue>[0-9]*.[0-9]*.[0-9]*)\"?"
       ]
     },
     {
@@ -20,9 +20,9 @@
         "/.github/workflows/release.yml/"
       ],
       "datasourceTemplate": "golang-version",
-      "depNameTemplate": "golang",
+      "depNameTemplate": "go",
       "matchStrings": [
-        "go-version: (?<currentValue>[0-9]*.[0-9]*.[0-9]*)"
+        "go-version: \"?(?<currentValue>[0-9]*.[0-9]*.[0-9]*)\"?"
       ]
     },
     {
@@ -31,10 +31,18 @@
         "/.github/workflows/go.yml/"
       ],
       "datasourceTemplate": "golang-version",
-      "depNameTemplate": "golang",
+      "depNameTemplate": "go",
       "matchStrings": [
-        "go-version: (?<currentValue>[0-9]*.[0-9]*.[0-9]*)"
+        "go-version: \"?(?<currentValue>[0-9]*.[0-9]*.[0-9]*)\"?"
       ]
+    }
+  ],
+  "packageRules": [
+    {
+      "matchDepNames": [
+        "go-security"
+      ],
+      "groupName": "go-version-security"
     }
   ],
   "postUpdateOptions": [


### PR DESCRIPTION
This pull request updates the `renovate.json` configuration to improve how Go version updates are handled in GitHub workflows. The main changes make the matching of Go version strings more robust, clarify dependency naming, and introduce grouping for security-related Go version updates.

**Improvements to Go version management in workflows:**

* Updated `matchStrings` patterns for Go version extraction to allow for optional quotes, making version matching more flexible in `.github/workflows/security.yml`, `.github/workflows/release.yml`, and `.github/workflows/go.yml`. [[1]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L12-R14) [[2]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L23-R25) [[3]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L34-R47)
* Changed `depNameTemplate` from `"golang"` to `"go"` or `"go-security"` for clarity and to distinguish between general and security-related Go version updates. [[1]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L12-R14) [[2]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L23-R25) [[3]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L34-R47)

**New grouping for security updates:**

* Added a `packageRules` entry to group all `go-security` dependency updates under the name `"go-version-security"`, allowing for easier management of security-related Go version bumps.