### PR TITLE
use go fix

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -153,7 +153,7 @@ func (c *CLI) run(target string, debug bool, bufSize int) int {
 }
 
 func blen(b [256]byte) int {
-	for i := 0; i < len(b); i++ {
+	for i := range len(b) {
 		if b[i] == 0 {
 			return i
 		}

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"bytes"
 	"os"
-	"sort"
+	"slices"
 	"strings"
 	"testing"
 
@@ -22,7 +22,7 @@ func TestRun_Success(t *testing.T) {
 	// last element is unused
 	actualList = actualList[:len(actualList)-1]
 	expectedList := dirList(t, target)
-	sort.Slice(actualList, func(i, j int) bool { return actualList[i] < actualList[j] })
+	slices.Sort(actualList)
 
 	if diff := cmp.Diff(actualList, expectedList); diff != "" {
 		t.Errorf("file list mismatch (-actual +expected):\n%s", diff)

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/catatsuy/lls
 
-go 1.24.4
+go 1.25.0
 
 require github.com/google/go-cmp v0.7.0


### PR DESCRIPTION
This pull request updates the codebase to use newer Go language features and simplifies some standard library usage. The most notable changes are the upgrade to Go 1.25 and the replacement of `sort` with `slices` for sorting, reflecting modern Go best practices.

**Go version upgrade:**
* Updated the Go version in `go.mod` from 1.24.4 to 1.25.0, enabling the use of new language features and standard library improvements.

**Standard library modernization:**
* Replaced the use of the `sort` package with the `slices` package for sorting in tests (`cli_test.go`), using `slices.Sort` for simpler and more idiomatic code. [[1]](diffhunk://#diff-9b4bb0842b486c4e5cc8995a96e409c9cae71bdaa96c00a9df80cebf0446a40dL6-R6) [[2]](diffhunk://#diff-9b4bb0842b486c4e5cc8995a96e409c9cae71bdaa96c00a9df80cebf0446a40dL25-R25)

**Code simplification:**
* Refactored the `blen` function in `cli.go` to use `for i := range len(b)` instead of `for i := 0; i < len(b); i++`, leveraging Go 1.25's new range-over-integers syntax for improved readability.